### PR TITLE
Update docs for v2.0 production status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.0.0 - Complete Platform Evolution
 **Release Date**: 2025-05-28  
 **Build**: Production Ready
+**Status**: Production Release (v2.0.0)
 This version is considered stable and recommended for production deployments.
 
 **Migration**: Breaking Changes - See Migration Guide

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </div>
 
 
-**Disclaimer:** CAM Protocol is currently in a **pre-release** state and some components are still under development. See [ROADMAP.md](ROADMAP.md) for expected timelines and planned features.
+**Production Status:** CAM Protocol is **production ready** as of the [v2.0.0 release](CHANGELOG.md) on May 28, 2025.
 
 
 ## 🌟 Overview

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ The CAM Protocol reached production-ready status with the **2.0.0** release on M
 
 | Milestone | Status | Description |
 |-----------|--------|-------------|
-| v1.0.0 | 📅 Planned (July 2025) | First stable release with production SLAs |
+| v2.1.0 | 📅 Planned (July 2025) | First minor update with production SLAs |
 | Kubernetes Operator | 📅 Planned | Native Kubernetes integration for simplified deployment |
 | Observability Enhancements | 📅 Planned | OpenTelemetry integration and Grafana dashboards |
 | Natural Language Interface | 📅 Planned | Premium feature for Growth+ tier customers |
@@ -30,7 +30,7 @@ The CAM Protocol reached production-ready status with the **2.0.0** release on M
 
 | Milestone | Status | Description |
 |-----------|--------|-------------|
-| v1.1.0 | 📅 Planned | Enhanced routing algorithms and cost optimization |
+| v2.2.0 | 📅 Planned | Enhanced routing algorithms and cost optimization |
 | Multi-Region Support | 📅 Planned | Geo-distributed deployment capabilities |
 | Voice Interface | 📅 Planned | Premium feature for Professional+ tier customers |
 | Community Plugin System | 📅 Planned | Framework for third-party extensions |
@@ -39,7 +39,7 @@ The CAM Protocol reached production-ready status with the **2.0.0** release on M
 
 | Milestone | Status | Description |
 |-----------|--------|-------------|
-| v1.2.0 | 📅 Planned | Advanced failure prediction and prevention |
+| v2.3.0 | 📅 Planned | Advanced failure prediction and prevention |
 | Custom Domain Adaptation | 📅 Planned | Premium feature for Enterprise tier customers |
 | Edge Deployment | 📅 Planned | Support for edge computing environments |
 | Federated Learning | 📅 Planned | Distributed model training coordination |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,7 +2,7 @@
 
 Get up and running with Complete Arbitration Mesh in minutes.
 
-> **Disclaimer:** This project is in **pre-release** and some components are actively being developed. Refer to [ROADMAP.md](../ROADMAP.md) for planned features and timelines.
+> **Version:** This guide applies to **CAM Protocol v2.0.0**, released May 28, 2025. See [ROADMAP.md](../ROADMAP.md) for upcoming features.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- mark project as production ready in README and Quick Start docs
- clarify production release version in CHANGELOG
- adjust roadmap to use v2.x milestones

## Testing
- `npm test` *(fails: vitest not found)*